### PR TITLE
Migrate the photo uploader off deprecated st.components.v1.html -> st…

### DIFF
--- a/pages/add_book_photos.py
+++ b/pages/add_book_photos.py
@@ -17,7 +17,6 @@ the #63 ISBN/copyright-page machinery reachable (#103) for AI-assisted data entr
 
 import s3fs
 import streamlit as st
-import streamlit.components.v1 as components
 import anthropic
 
 from text_content import BookPhotoEntry
@@ -137,7 +136,10 @@ st.write(BookPhotoEntry.direct_upload_instructions)
 # listing the S3 prefix when the user clicks "Read the book".
 session_id = get_upload_session_id()
 put_urls = generate_put_urls(session_id)
-components.html(build_uploader_html(put_urls), height=460, scrolling=True)
+# st.iframe (Streamlit 1.56+) replaces the deprecated st.components.v1.html. An HTML
+# string is embedded via srcdoc exactly as before (same-origin preserved, so the
+# browser→S3 PUT still uses the app origin that the S3 CORS policy allows).
+st.iframe(build_uploader_html(put_urls), height=460)
 
 read_clicked = st.button(
     BookPhotoEntry.read_button,

--- a/photo_upload.py
+++ b/photo_upload.py
@@ -203,6 +203,9 @@ _UPLOADER_TEMPLATE = """
     #ftu .ftu-status { width: 1.4rem; text-align: center; font-weight: 700; }
     #ftu .ftu-status.ok { color: #1f9d55; }
     #ftu .ftu-status.err { color: #d1453b; }
+    /* Bound the per-photo list so a long book scrolls internally (st.iframe has no
+       `scrolling` param like the old components.html). */
+    #ftu #ftu-list { max-height: 300px; overflow-y: auto; }
     #ftu #ftu-summary { margin-top: 0.75rem; font-weight: 600; }
   </style>
 


### PR DESCRIPTION
….iframe

st.components.v1.html is deprecated (removed in a later Streamlit). st.iframe embeds an HTML string via the same srcdoc mechanism (same-origin preserved, so the browser->S3 PUT keeps the app origin the CORS policy allows). st.iframe has no 'scrolling' param, so bound the per-photo list with an internal max-height/overflow scroll. Removes the deprecation warning in the Streamlit Cloud logs.

Claude-Session: https://claude.ai/code/session_017Q5oF8pted9UKzXvb3MwTE